### PR TITLE
refactor: simplify token tracking — use subagent isolation instead

### DIFF
--- a/data/token-snapshot.json
+++ b/data/token-snapshot.json
@@ -1,0 +1,3 @@
+{
+  "daniyuu/show-me-your-think#14": 2789
+}

--- a/src/backend/lib/job-service.ts
+++ b/src/backend/lib/job-service.ts
@@ -232,15 +232,15 @@ export class JobService {
 
   // --- Work Log ---
 
-  takeJob(jobId: number, tokensAtStart?: number): number {
+  takeJob(jobId: number): number {
     const existing = this.db.prepare(
       "SELECT id FROM work_log WHERE job_id = $job_id AND status IN ('taken', 'in_progress')"
     ).get({ job_id: jobId });
     if (existing) throw new Error("Already working on this job");
 
     const result = this.db.prepare(
-      "INSERT INTO work_log (job_id, status, tokens_at_start) VALUES ($job_id, 'taken', $tokens_at_start)"
-    ).run({ job_id: jobId, tokens_at_start: tokensAtStart ?? null });
+      "INSERT INTO work_log (job_id, status) VALUES ($job_id, 'taken')"
+    ).run({ job_id: jobId });
     return Number(result.lastInsertRowid);
   }
 
@@ -248,20 +248,12 @@ export class JobService {
     pr_number?: number;
     pr_url?: string;
     tokens_used?: number;
-    tokens_at_end?: number;
     notes?: string;
   }): void {
     const entry = this.db.prepare(
-      "SELECT id, tokens_at_start FROM work_log WHERE job_id = $job_id AND status IN ('taken', 'in_progress') ORDER BY taken_at DESC LIMIT 1"
-    ).get({ job_id: jobId }) as { id: number; tokens_at_start: number | null } | undefined;
+      "SELECT id FROM work_log WHERE job_id = $job_id AND status IN ('taken', 'in_progress') ORDER BY taken_at DESC LIMIT 1"
+    ).get({ job_id: jobId }) as { id: number } | undefined;
     if (!entry) throw new Error("No active work entry for this job");
-
-    // Auto-calculate tokens_used from snapshots if available
-    let tokensUsed = data.tokens_used ?? null;
-    const tokensAtEnd = data.tokens_at_end ?? null;
-    if (tokensAtEnd !== null && entry.tokens_at_start !== null && tokensUsed === null) {
-      tokensUsed = tokensAtEnd - entry.tokens_at_start;
-    }
 
     this.db.prepare(`
       UPDATE work_log SET
@@ -269,15 +261,13 @@ export class JobService {
         pr_number = COALESCE($pr_number, pr_number),
         pr_url = COALESCE($pr_url, pr_url),
         tokens_used = COALESCE($tokens_used, tokens_used),
-        tokens_at_end = $tokens_at_end,
         notes = COALESCE($notes, notes),
         completed_at = datetime('now')
       WHERE id = $id
     `).run({
       pr_number: data.pr_number ?? null,
       pr_url: data.pr_url ?? null,
-      tokens_used: tokensUsed,
-      tokens_at_end: tokensAtEnd,
+      tokens_used: data.tokens_used ?? null,
       notes: data.notes ?? null,
       id: entry.id,
     });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2,7 +2,6 @@
 
 import { Command } from "commander";
 import path from "path";
-import fs from "fs";
 import Database from "better-sqlite3";
 import { runMigrations } from "../backend/lib/migrations";
 import { JobService } from "../backend/lib/job-service";
@@ -22,41 +21,6 @@ function getDb(): Database.Database {
 
 function getService(): JobService {
   return new JobService(getDb());
-}
-
-// --- Token snapshot ---
-const snapshotPath = path.join(dataDir, "token-snapshot.json");
-
-/** Read current session token count from env or snapshot file */
-function getCurrentTokens(): number | null {
-  // Prefer env var (set by the agent before calling CLI)
-  const envTokens = process.env.GOGETAJOB_SESSION_TOKENS;
-  if (envTokens) return parseInt(envTokens, 10) || null;
-  return null;
-}
-
-/** Save token snapshot for a job (at start time) */
-function saveTokenSnapshot(jobRef: string, tokens: number): void {
-  let snapshots: Record<string, number> = {};
-  try {
-    if (fs.existsSync(snapshotPath)) {
-      snapshots = JSON.parse(fs.readFileSync(snapshotPath, "utf-8"));
-    }
-  } catch {}
-  snapshots[jobRef] = tokens;
-  fs.mkdirSync(path.dirname(snapshotPath), { recursive: true });
-  fs.writeFileSync(snapshotPath, JSON.stringify(snapshots, null, 2));
-}
-
-/** Load token snapshot for a job (saved at start time) */
-function loadTokenSnapshot(jobRef: string): number | null {
-  try {
-    if (!fs.existsSync(snapshotPath)) return null;
-    const snapshots = JSON.parse(fs.readFileSync(snapshotPath, "utf-8"));
-    return snapshots[jobRef] ?? null;
-  } catch {
-    return null;
-  }
 }
 
 // --- CLI ---
@@ -275,16 +239,10 @@ program
 
     console.log(`\n🚀 Starting work on ${ref}...\n`);
 
-    // 1. Take the job (with token snapshot)
-    const startTokens = getCurrentTokens();
+    // 1. Take the job
     try {
-      svc.takeJob(job.id, startTokens ?? undefined);
-      if (startTokens !== null) {
-        saveTokenSnapshot(ref, startTokens);
-        console.log(`  ✅ Job taken (📊 token snapshot: ${startTokens.toLocaleString()})`);
-      } else {
-        console.log(`  ✅ Job taken`);
-      }
+      svc.takeJob(job.id);
+      console.log(`  ✅ Job taken`);
     } catch (e: any) {
       if (e.message.includes("Already working")) {
         console.log(`  ℹ️  Already taken — continuing setup`);
@@ -426,14 +384,11 @@ program
       const prNumber = prMatch ? parseInt(prMatch[1]) : undefined;
 
       // Record completion
-      const endTokens = getCurrentTokens();
-      const manualTokens = opts.tokens ? parseInt(opts.tokens) : undefined;
       try {
         svc.completeJob(job.id, {
           pr_number: prNumber,
           pr_url: prUrl,
-          tokens_used: manualTokens,
-          tokens_at_end: endTokens ?? undefined,
+          tokens_used: opts.tokens ? parseInt(opts.tokens) : undefined,
           notes: opts.notes,
         });
         console.log(`  ✅ Job recorded as done`);
@@ -443,14 +398,7 @@ program
 
       console.log(`\n🎉 All done!`);
       console.log(`   PR: ${prUrl}`);
-      // Show token info
-      const startSnapshot = loadTokenSnapshot(ref);
-      if (endTokens !== null && startSnapshot !== null) {
-        const actual = endTokens - startSnapshot;
-        console.log(`   📊 Tokens: ${actual.toLocaleString()} (measured: ${startSnapshot.toLocaleString()} → ${endTokens.toLocaleString()})`);
-      } else if (manualTokens) {
-        console.log(`   Tokens: ${manualTokens} (manual estimate)`);
-      }
+      if (opts.tokens) console.log(`   Tokens: ${parseInt(opts.tokens).toLocaleString()}`);
       console.log();
     } catch (e: any) {
       const msg = e.stderr || e.message || String(e);
@@ -495,7 +443,7 @@ program
   .command("done <ref>")
   .description("Mark a job as completed")
   .option("--pr <number>", "PR number")
-  .option("--tokens <count>", "tokens consumed (auto-calculated if snapshot exists)")
+  .option("--tokens <count>", "tokens consumed")
   .option("--notes <text>", "completion notes")
   .action((ref: string, opts: any) => {
     const parsed = parseRef(ref);
@@ -507,28 +455,17 @@ program
       process.exit(1);
     }
 
-    const endTokens = getCurrentTokens();
-    const manualTokens = opts.tokens ? parseInt(opts.tokens) : undefined;
-
     try {
       svc.completeJob(job.id, {
         pr_number: opts.pr ? parseInt(opts.pr) : undefined,
         pr_url: opts.pr ? `https://github.com/${parsed.owner}/${parsed.repo}/pull/${opts.pr}` : undefined,
-        tokens_used: manualTokens,
-        tokens_at_end: endTokens ?? undefined,
+        tokens_used: opts.tokens ? parseInt(opts.tokens) : undefined,
         notes: opts.notes,
       });
       console.log(`\n🎉 Job done!`);
       console.log(`   ${job.title}`);
       if (opts.pr) console.log(`   PR: #${opts.pr}`);
-      // Show token info
-      const startSnapshot = loadTokenSnapshot(ref);
-      if (endTokens !== null && startSnapshot !== null) {
-        const actual = endTokens - startSnapshot;
-        console.log(`   📊 Tokens: ${actual.toLocaleString()} (measured: ${startSnapshot.toLocaleString()} → ${endTokens.toLocaleString()})`);
-      } else if (manualTokens) {
-        console.log(`   Tokens: ${manualTokens} (manual estimate)`);
-      }
+      if (opts.tokens) console.log(`   Tokens: ${parseInt(opts.tokens).toLocaleString()}`);
       console.log();
     } catch (e: any) {
       console.error(`Error: ${e.message}`);


### PR DESCRIPTION
## Problem

The session snapshot approach (GOGETAJOB_SESSION_TOKENS env var) was unreliable:
- Mixed metrics (incremental tokens vs context size)
- Polluted data (chat tokens mixed with work tokens)
- Over-engineered for something that doesn't work

## Solution

Remove the snapshot mechanism entirely. Token tracking belongs at the **agent level**, not the CLI tool:

1. Agent spawns a **subagent** for each task
2. Subagent does the work in an isolated session
3. Agent reads subagent's `session_status` for precise token count
4. Agent passes the real number via `--tokens`

The CLI stays simple: `--tokens` is the single input, always accurate.

## Changes

- Remove snapshot env var, file read/write, and auto-calculation
- Simplify `takeJob()` and `completeJob()` back to basics
- Keep DB migration columns (harmless, no data loss)

Closes #20