### PR TITLE
fix: UX polish — stale issues, upstream noise, submit warnings

### DIFF
--- a/src/backend/lib/github.ts
+++ b/src/backend/lib/github.ts
@@ -266,13 +266,16 @@ export function createBranch(repoDir: string, branchName: string): void {
 /** Add upstream remote if working from a fork */
 export function addUpstreamRemote(repoDir: string, upstreamOwner: string, repo: string): void {
   const { execSync: exec } = require("child_process");
+  // Check if upstream already exists
   try {
+    exec("git remote get-url upstream", { cwd: repoDir, encoding: "utf-8", stdio: "pipe" });
+    // Already exists — no-op
+  } catch {
+    // Doesn't exist — add it
     exec(`git remote add upstream https://github.com/${upstreamOwner}/${repo}.git`, {
       cwd: repoDir,
       encoding: "utf-8",
     });
-  } catch {
-    // Remote might already exist
   }
 }
 

--- a/src/backend/lib/job-service.ts
+++ b/src/backend/lib/job-service.ts
@@ -185,6 +185,30 @@ export class JobService {
     return row?.id ?? 0;
   }
 
+  /** Mark jobs as closed if they're no longer in the open issues set */
+  closeStaleJobs(companyId: number, openIssueNumbers: Set<number>): number {
+    if (openIssueNumbers.size === 0) {
+      // If no open issues at all, close everything for this company
+      const result = this.db.prepare(
+        "UPDATE jobs SET state = 'closed' WHERE company_id = $company_id AND state = 'open'"
+      ).run({ company_id: companyId });
+      return result.changes;
+    }
+
+    const openJobs = this.db.prepare(
+      "SELECT id, issue_number FROM jobs WHERE company_id = $company_id AND state = 'open'"
+    ).all({ company_id: companyId }) as { id: number; issue_number: number }[];
+
+    let closed = 0;
+    for (const job of openJobs) {
+      if (!openIssueNumbers.has(job.issue_number)) {
+        this.db.prepare("UPDATE jobs SET state = 'closed' WHERE id = $id").run({ id: job.id });
+        closed++;
+      }
+    }
+    return closed;
+  }
+
   listJobs(filters: { lang?: string; type?: string; limit?: number } = {}): Job[] {
     const conditions: string[] = ["j.state = 'open'"];
     const params: Record<string, any> = {};

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -148,7 +148,9 @@ program
     });
 
     let added = 0;
+    const openIssueNumbers = new Set<number>();
     for (const issue of issues) {
+      openIssueNumbers.add(issue.number);
       const classified = gh.classifyIssue(issue);
       svc.upsertJob(companyId, {
         issue_number: issue.number,
@@ -163,6 +165,12 @@ program
         comments_count: issue.comments,
       });
       added++;
+    }
+
+    // Mark issues no longer open as closed
+    const closed = svc.closeStaleJobs(companyId, openIssueNumbers);
+    if (closed > 0) {
+      console.log(`  🔒 ${closed} issues marked as closed`);
     }
 
     console.log(`  📋 ${added} issues discovered`);
@@ -351,15 +359,25 @@ program
     } else {
       // Check if there are commits ahead of origin
       try {
-        const ahead = exec("git rev-list --count @{u}..HEAD", { cwd: repoDir, encoding: "utf-8" }).trim();
+        const ahead = exec("git rev-list --count @{u}..HEAD", { cwd: repoDir, encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] }).trim();
         if (ahead === "0") {
           console.error(`  ❌ No changes to submit. Make some changes first!`);
           process.exit(1);
         }
         console.log(`  ℹ️  No uncommitted changes — using ${ahead} existing commit(s)`);
       } catch {
-        // No upstream set, probably has local commits
-        console.log(`  ℹ️  No uncommitted changes — using existing commits`);
+        // No upstream set — check if we have any local commits at all
+        try {
+          const logCount = exec("git rev-list --count HEAD", { cwd: repoDir, encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] }).trim();
+          if (parseInt(logCount) > 0) {
+            console.log(`  ℹ️  No uncommitted changes — using existing commits`);
+          } else {
+            console.error(`  ❌ No changes to submit. Make some changes first!`);
+            process.exit(1);
+          }
+        } catch {
+          console.log(`  ℹ️  No uncommitted changes — using existing commits`);
+        }
       }
     }
 


### PR DESCRIPTION
Three annoyances fixed in one go:

## 1. feed shows closed issues (Closes #23)
`scan` now tracks which issues are still open on GitHub. After upserting fresh data, any existing DB records NOT in the open list are marked `state='closed'`. Feed goes from 7 stale entries to 2 real ones.

## 2. 'upstream already exists' noise
`addUpstreamRemote` now checks if the remote exists before trying to add it. No more stderr errors on repeat `start` calls for the same repo.

## 3. 'fatal: no upstream configured for branch' noise  
`submit` now captures git's stderr via stdio pipes instead of letting it leak to console. Better fallback logic to detect local commits when no upstream tracking is set.