### PR TITLE
feat: enforce issue lifecycle — block start on self-filed unadopted issues

### DIFF
--- a/src/backend/lib/job-service.ts
+++ b/src/backend/lib/job-service.ts
@@ -317,10 +317,11 @@ export class JobService {
     output_status?: string;
     tokens_used?: number;
     notes?: string;
+    filed_by?: string;
   }): number {
     const result = this.db.prepare(`
-      INSERT INTO work_log (job_id, status, work_type, output_repo, output_number, output_url, output_status, tokens_used, notes, completed_at)
-      VALUES (NULL, 'done', $work_type, $output_repo, $output_number, $output_url, $output_status, $tokens_used, $notes, datetime('now'))
+      INSERT INTO work_log (job_id, status, work_type, output_repo, output_number, output_url, output_status, tokens_used, notes, filed_by, completed_at)
+      VALUES (NULL, 'done', $work_type, $output_repo, $output_number, $output_url, $output_status, $tokens_used, $notes, $filed_by, datetime('now'))
     `).run({
       work_type: data.work_type,
       output_repo: data.output_repo,
@@ -329,6 +330,7 @@ export class JobService {
       output_status: data.output_status ?? "open",
       tokens_used: data.tokens_used ?? null,
       notes: data.notes ?? null,
+      filed_by: data.filed_by ?? null,
     });
     return Number(result.lastInsertRowid);
   }
@@ -353,6 +355,18 @@ export class JobService {
     this.db.prepare(
       "UPDATE work_log SET output_status = $status, pr_status = $status WHERE id = $id"
     ).run({ status, id: workLogId });
+  }
+
+  /** Check if an issue was filed by us and hasn't been adopted yet */
+  isSelfFiledUnadopted(repo: string, issueNumber: number): boolean {
+    const entry = this.db.prepare(`
+      SELECT filed_by, output_status FROM work_log
+      WHERE work_type = 'issue' AND output_repo = $repo AND output_number = $issue
+      ORDER BY id DESC LIMIT 1
+    `).get({ repo, issue: issueNumber }) as { filed_by: string | null; output_status: string | null } | undefined;
+
+    if (!entry || !entry.filed_by) return false;
+    return !["adopted", "discussing", "closed"].includes(entry.output_status || "");
   }
 
   listWorkHistory(filters: { repo?: string; status?: string } = {}): WorkEntry[] {

--- a/src/backend/lib/migrations.ts
+++ b/src/backend/lib/migrations.ts
@@ -134,4 +134,11 @@ export function runMigrations(db: Database.Database): void {
       ALTER TABLE work_log_new RENAME TO work_log;
     `);
   }
+
+  // Migration 5: add filed_by for issue lifecycle tracking
+  const wlCols5 = db.prepare(`PRAGMA table_info(work_log)`).all() as any[];
+  const wlColNames5 = wlCols5.map((c: any) => c.name);
+  if (!wlColNames5.includes('filed_by')) {
+    db.exec(`ALTER TABLE work_log ADD COLUMN filed_by TEXT`);
+  }
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -235,6 +235,7 @@ program
   .command("start <ref>")
   .description("Take a job + fork/clone/branch — ready to code (format: owner/repo#issue_number)")
   .option("--dir <path>", "custom work directory", "/tmp/work")
+  .option("--force", "override self-filed issue guard")
   .action((ref: string, opts: any) => {
     const parsed = parseRef(ref);
     const svc = getService();
@@ -243,6 +244,16 @@ program
     if (!job) {
       console.error(`Job not found: ${ref}. Run \`gogetajob scan ${parsed.owner}/${parsed.repo}\` first.`);
       process.exit(1);
+    }
+
+    // Guard: don't start self-filed issues until owner responds
+    if (svc.isSelfFiledUnadopted(`${parsed.owner}/${parsed.repo}`, parsed.issue)) {
+      if (!opts.force) {
+        console.error(`\n⛔ This issue was filed by you and hasn't been acknowledged by the owner yet.`);
+        console.error(`   Wait for the owner to respond, or use --force to override.\n`);
+        process.exit(1);
+      }
+      console.log(`\n⚠️  Overriding self-filed guard (--force)\n`);
     }
 
     console.log(`\n🚀 Starting work on ${ref}...\n`);
@@ -797,6 +808,7 @@ program
               output_status: "open",
               tokens_used: opts.tokens ? Math.round(parseInt(opts.tokens) / findings.length) : undefined,
               notes: `audit: ${finding.split(" — ")[0]}`,
+              filed_by: gh.getMyLogin(),
             });
           }
         } catch (e: any) {


### PR DESCRIPTION
Self-filed issues must be acknowledged by the repo owner before the agent can start working on them. `start` refuses with a clear message; `--force` overrides.

Depends on PR#32 (multi work types). Tested: guard blocks correctly, --force overrides ✅

Closes #30