### PR TITLE
fix: sync handles deleted issues gracefully

### DIFF
--- a/src/backend/lib/job-service.ts
+++ b/src/backend/lib/job-service.ts
@@ -344,6 +344,7 @@ export class JobService {
       LEFT JOIN companies c ON j.company_id = c.id
       WHERE w.status = 'done'
         AND (w.pr_number IS NOT NULL OR w.output_number IS NOT NULL)
+        AND COALESCE(w.output_status, '') NOT IN ('deleted')
       ORDER BY w.taken_at DESC
     `).all();
   }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -582,7 +582,14 @@ program
         else if (newStatus === "closed") issueClosed++;
         else issueOpen++;
       } catch (e: any) {
-        console.log(`  ⚠️  [Issue] ${entry.output_repo}#${entry.output_number} — failed to check`);
+        const msg = String(e.message || e);
+        if (msg.includes("Could not resolve")) {
+          svc.updateOutputStatus(entry.id, "deleted");
+          console.log(`  🗑️  [Issue] ${entry.output_repo}#${entry.output_number} — deleted`);
+          issueClosed++;
+        } else {
+          console.log(`  ⚠️  [Issue] ${entry.output_repo}#${entry.output_number} — failed to check`);
+        }
       }
     }
 


### PR DESCRIPTION
Deleted issues no longer spam GraphQL errors. Marked as 'deleted' and excluded from future syncs.

Tested: deleted issues show 🗑️ once then disappear ✅

Closes #36