### PR TITLE
feat: start/check/submit accept short issue number

### DIFF
--- a/src/backend/lib/job-service.ts
+++ b/src/backend/lib/job-service.ts
@@ -254,6 +254,17 @@ export class JobService {
     return { ...row, labels: JSON.parse(row.labels || "[]"), has_bounty: !!row.has_bounty, has_pr: !!row.has_pr, comments_count: row.comments_count ?? 0 };
   }
 
+  /** Find a job by issue number alone (for short-form refs) */
+  findJobByIssueNumber(issueNumber: number): { owner: string; repo: string } | null {
+    const row = this.db.prepare(`
+      SELECT c.owner, c.repo FROM jobs j
+      JOIN companies c ON j.company_id = c.id
+      WHERE j.issue_number = $issue
+      LIMIT 1
+    `).get({ issue: issueNumber }) as { owner: string; repo: string } | undefined;
+    return row || null;
+  }
+
   // --- Work Log ---
 
   takeJob(jobId: number): number {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -812,10 +812,25 @@ program.parse();
 // === Helpers ===
 
 function parseRef(ref: string): { owner: string; repo: string; issue: number } {
+  // Full format: owner/repo#issue_number
   const match = ref.match(/^([^\/]+)\/([^#]+)#(\d+)$/);
-  if (!match) {
-    console.error(`Invalid format: "${ref}". Expected: owner/repo#issue_number`);
+  if (match) {
+    return { owner: match[1]!, repo: match[2]!, issue: parseInt(match[3]!) };
+  }
+
+  // Short format: just a number (e.g., "34" or "#34")
+  const numMatch = ref.match(/^#?(\d+)$/);
+  if (numMatch) {
+    const issueNum = parseInt(numMatch[1]!);
+    const svc = getService();
+    const job = svc.findJobByIssueNumber(issueNum);
+    if (job) {
+      return { owner: job.owner, repo: job.repo, issue: issueNum };
+    }
+    console.error(`No job found for issue #${issueNum}. Use full format: owner/repo#${issueNum}`);
     return process.exit(1);
   }
-  return { owner: match[1]!, repo: match[2]!, issue: parseInt(match[3]!) };
+
+  console.error(`Invalid format: "${ref}". Expected: owner/repo#issue_number or just the issue number`);
+  return process.exit(1);
 }


### PR DESCRIPTION
No more typing `owner/repo#number` every time. Just `gogetajob start 34`.

Tested: `check 34` ✅, `start 35` ✅

Closes #35