### PR TITLE
fix: sync detects owner comments as adoption signal

### DIFF
--- a/src/backend/lib/github.ts
+++ b/src/backend/lib/github.ts
@@ -369,12 +369,21 @@ export function getIssueStatus(owner: string, repo: string, issueNumber: number)
   state: string;
   comments: number;
   hasLinkedPR: boolean;
+  hasNonAuthorComment: boolean;
 } {
   const data = ghJson(
-    `issue view ${issueNumber} -R ${owner}/${repo} --json state,comments`
+    `issue view ${issueNumber} -R ${owner}/${repo} --json state,comments,author`
   );
   const state = (data.state || "OPEN").toLowerCase();
-  const comments = data.comments?.length ?? 0;
+  const issueAuthor = data.author?.login || "";
+  const commentsList = data.comments || [];
+  const comments = commentsList.length;
+
+  // Check if someone other than the issue author commented
+  const hasNonAuthorComment = commentsList.some(
+    (c: any) => c.author?.login && c.author.login !== issueAuthor
+  );
+
   const { hasPR } = checkLinkedPRs(owner, repo, issueNumber);
-  return { state, comments, hasLinkedPR: hasPR };
+  return { state, comments, hasLinkedPR: hasPR, hasNonAuthorComment };
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -581,10 +581,12 @@ program
         const issueData = gh.getIssueStatus(repoOwner, repoName, entry.output_number!);
         const newStatus = issueData.state === "closed" ? "closed"
           : issueData.hasLinkedPR ? "adopted"
+          : issueData.hasNonAuthorComment ? "discussing"
           : "open";
         svc.updateOutputStatus(entry.id, newStatus);
 
         const icon = newStatus === "adopted" ? "🎯"
+          : newStatus === "discussing" ? "💬"
           : newStatus === "closed" ? "🔒"
           : "🔵";
         console.log(`  ${icon} [Issue] ${entry.output_repo}#${entry.output_number} — ${newStatus}${issueData.comments > 0 ? ` (${issueData.comments} comments)` : ""}`);


### PR DESCRIPTION
Owner comments now unlock the start guard. Closes #39.