### PR TITLE
fix: use parseAsync() for async commander actions

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -844,7 +844,7 @@ program
     }
   });
 
-program.parse();
+program.parseAsync();
 
 // === Helpers ===
 


### PR DESCRIPTION
## Problem

`program.parse()` doesn't await async action handlers in Commander.js. When `scan` runs, the `upsertCompany` call inside the async handler hasn't resolved before `upsertJob` executes, causing:

```
SqliteError: FOREIGN KEY constraint failed
```

## Fix

Replace `program.parse()` with `program.parseAsync()` so async actions are properly awaited.

## Found by

Discovered while testing the latest GoGetAJob CLI after syncing to main.