### PR TITLE
fix: feat: import command — backfill work_log from GitHub PR history

### DIFF
--- a/src/backend/lib/github.ts
+++ b/src/backend/lib/github.ts
@@ -387,3 +387,55 @@ export function getIssueStatus(owner: string, repo: string, issueNumber: number)
   const { hasPR } = checkLinkedPRs(owner, repo, issueNumber);
   return { state, comments, hasLinkedPR: hasPR, hasNonAuthorComment };
 }
+
+export interface MyPRInfo {
+  number: number;
+  title: string;
+  state: string; // OPEN, MERGED, CLOSED
+  url: string;
+  createdAt: string;
+  mergedAt: string | null;
+  closedAt: string | null;
+  body: string;
+  linkedIssueNumber: number | null;
+}
+
+export function getMyPRs(owner: string, repo: string): MyPRInfo[] {
+  const myLogin = getMyLogin();
+  const raw = ghJson(
+    `pr list -R ${owner}/${repo} --author ${myLogin} --state all --json number,title,state,url,createdAt,mergedAt,closedAt,body --limit 200`
+  );
+  if (!Array.isArray(raw)) return [];
+
+  return raw.map((pr: any) => {
+    // Try to extract linked issue number from PR body or title
+    // Common patterns: "Closes #N", "Fixes #N", "#N", "owner/repo#N"
+    let linkedIssue: number | null = null;
+    const text = `${pr.body || ""} ${pr.title || ""}`;
+    const patterns = [
+      new RegExp(`(?:closes|fixes|resolves)\\s+#(\\d+)`, "i"),
+      new RegExp(`(?:closes|fixes|resolves)\\s+${owner}/${repo}#(\\d+)`, "i"),
+      new RegExp(`${owner}/${repo}#(\\d+)`),
+      /\b#(\d+)\b/,
+    ];
+    for (const pat of patterns) {
+      const m = text.match(pat);
+      if (m) {
+        linkedIssue = parseInt(m[1]);
+        break;
+      }
+    }
+
+    return {
+      number: pr.number,
+      title: pr.title,
+      state: pr.state,
+      url: pr.url,
+      createdAt: pr.createdAt,
+      mergedAt: pr.mergedAt || null,
+      closedAt: pr.closedAt || null,
+      body: pr.body || "",
+      linkedIssueNumber: linkedIssue,
+    };
+  });
+}

--- a/src/backend/lib/job-service.ts
+++ b/src/backend/lib/job-service.ts
@@ -534,4 +534,68 @@ export class JobService {
       needs_action: needsAction,
     };
   }
+
+  /** Check if a PR number already exists in work_log for a given repo */
+  hasPRInLog(owner: string, repo: string, prNumber: number): boolean {
+    // Check by job_id association
+    const byJob = this.db.prepare(`
+      SELECT id FROM work_log
+      WHERE pr_number = $pr_number
+        AND job_id IN (
+          SELECT j.id FROM jobs j
+          JOIN companies c ON j.company_id = c.id
+          WHERE c.owner = $owner AND c.repo = $repo
+        )
+    `).get({ pr_number: prNumber, owner, repo });
+    if (byJob) return true;
+
+    // Also check by pr_url pattern (catches entries without job_id)
+    const byUrl = this.db.prepare(`
+      SELECT id FROM work_log
+      WHERE pr_number = $pr_number
+        AND (pr_url LIKE $url_pattern OR output_repo = $full_name)
+    `).get({
+      pr_number: prNumber,
+      url_pattern: `%${owner}/${repo}/pull/${prNumber}`,
+      full_name: `${owner}/${repo}`,
+    });
+    return !!byUrl;
+  }
+
+  /** Import a PR into work_log, linking to a job if possible */
+  importPR(data: {
+    owner: string;
+    repo: string;
+    issueNumber: number | null;
+    prNumber: number;
+    prUrl: string;
+    prStatus: string;
+    notes: string;
+    createdAt: string;
+    completedAt: string | null;
+  }): number {
+    // Try to find a matching job
+    let jobId: number | null = null;
+    if (data.issueNumber) {
+      const job = this.getJob(data.owner, data.repo, data.issueNumber);
+      if (job) {
+        jobId = job.id;
+      }
+    }
+
+    const result = this.db.prepare(`
+      INSERT INTO work_log (job_id, status, pr_number, pr_url, pr_status, notes, taken_at, completed_at, work_type)
+      VALUES ($job_id, $status, $pr_number, $pr_url, $pr_status, $notes, $taken_at, $completed_at, 'pr')
+    `).run({
+      job_id: jobId,
+      status: data.prStatus === "MERGED" || data.prStatus === "CLOSED" ? "done" : "taken",
+      pr_number: data.prNumber,
+      pr_url: data.prUrl,
+      pr_status: data.prStatus.toLowerCase(),
+      notes: data.notes,
+      taken_at: data.createdAt,
+      completed_at: data.completedAt,
+    });
+    return Number(result.lastInsertRowid);
+  }
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -709,6 +709,68 @@ program
     });
   });
 
+// ========== import ==========
+program
+  .command("import <repo>")
+  .description("Backfill work_log from GitHub PR history (format: owner/repo)")
+  .option("--dry-run", "show what would be imported without writing")
+  .action((repoArg: string, opts: any) => {
+    const [owner, repo] = repoArg.split("/");
+    if (!owner || !repo) {
+      console.error("Error: format should be owner/repo");
+      process.exit(1);
+    }
+
+    const svc = getService();
+    console.log(`\n📥 Importing PR history for ${owner}/${repo}...\n`);
+
+    const myPRs = gh.getMyPRs(owner, repo);
+    if (myPRs.length === 0) {
+      console.log("  No PRs found by you in this repo.\n");
+      return;
+    }
+
+    console.log(`  Found ${myPRs.length} PR(s) by ${gh.getMyLogin()}\n`);
+
+    let imported = 0;
+    let skipped = 0;
+
+    for (const pr of myPRs) {
+      // Check if already in work_log
+      if (svc.hasPRInLog(owner, repo, pr.number)) {
+        skipped++;
+        continue;
+      }
+
+      const icon = pr.state === "MERGED" ? "✅" :
+                   pr.state === "CLOSED" ? "❌" : "🔵";
+      const issueRef = pr.linkedIssueNumber ? ` (issue #${pr.linkedIssueNumber})` : "";
+
+      if (opts.dryRun) {
+        console.log(`  ${icon} Would import PR #${pr.number} — ${pr.title}${issueRef}`);
+        imported++;
+        continue;
+      }
+
+      svc.importPR({
+        owner,
+        repo,
+        issueNumber: pr.linkedIssueNumber,
+        prNumber: pr.number,
+        prUrl: pr.url,
+        prStatus: pr.state,
+        notes: pr.title,
+        createdAt: pr.createdAt,
+        completedAt: pr.mergedAt || pr.closedAt || null,
+      });
+
+      console.log(`  ${icon} Imported PR #${pr.number} — ${pr.title}${issueRef}`);
+      imported++;
+    }
+
+    console.log(`\n📊 ${opts.dryRun ? "Would import" : "Imported"}: ${imported} | Skipped (already tracked): ${skipped}\n`);
+  });
+
 // ========== audit ==========
 program
   .command("audit <repo>")
@@ -844,7 +906,7 @@ program
     }
   });
 
-program.parse();
+program.parseAsync();
 
 // === Helpers ===
 


### PR DESCRIPTION
Fixes #57

Added import command to backfill work_log from GitHub. Auto-detects issues, dedupes, supports dry-run.